### PR TITLE
Move adding spaces around punctuation to top

### DIFF
--- a/textgenrnn/textgenrnn.py
+++ b/textgenrnn/textgenrnn.py
@@ -128,6 +128,14 @@ class textgenrnn:
                        multi_gpu=False,
                        **kwargs):
 
+        if self.config['word_level']:
+            # If training word level, must add spaces around each
+            # punctuation. https://stackoverflow.com/a/3645946/9314418
+            punct = '!"#$%&()*+,-./:;<=>?@[\]^_`{|}~\\n\\t\'‘’“”’–—…'
+            for i in range(len(texts)):
+                texts[i] = re.sub('([{}])'.format(punct), r' \1 ', texts[i])
+                texts[i] = re.sub(' {2,}', ' ', texts[i])
+                
         if new_model and not via_new_model:
             self.train_new_model(texts,
                                  context_labels=context_labels,
@@ -146,12 +154,6 @@ class textgenrnn:
             context_labels = LabelBinarizer().fit_transform(context_labels)
 
         if self.config['word_level']:
-            # If training word level, must add spaces around each
-            # punctuation. https://stackoverflow.com/a/3645946/9314418
-            punct = '!"#$%&()*+,-./:;<=>?@[\]^_`{|}~\\n\\t\'‘’“”’–—…'
-            for i in range(len(texts)):
-                texts[i] = re.sub('([{}])'.format(punct), r' \1 ', texts[i])
-                texts[i] = re.sub(' {2,}', ' ', texts[i])
             texts = [text_to_word_sequence(text, filters='') for text in texts]
 
         # calculate all combinations of text indices + token indices


### PR DESCRIPTION
If adding space around each punctuation put after `train_new_model`, the Tokenizer didn't count punctuation as a whole word and didn't separate the sentence `"this sentence?"` to `["this", "sentence", "?"]` but into `["this", "sentence?"]`.